### PR TITLE
ignore stdio of child process

### DIFF
--- a/src/utils/child-process.js
+++ b/src/utils/child-process.js
@@ -12,7 +12,7 @@ export function runProcess(cmd) {
     return new Promise((resolve, reject) => {
         const commands = cmd.split(SPACE);
         const [app, ...args] = commands;
-        const childProcess = spawn(app, args);
+        const childProcess = spawn(app, args, { stdio: 'ignore' });
 
         childProcess.on('error', (err) => {
             reject(err);
@@ -33,7 +33,7 @@ export function runCommand(cmd) {
     return new Promise((resolve, reject) => {
         const commands = cmd.split(SPACE);
         const [app, ...args] = commands;
-        const childProcess = spawn(app, args);
+        const childProcess = spawn(app, args, { stdio: 'ignore' });
 
         childProcess.on('error', (err) => {
             reject(err);

--- a/src/utils/child-process.js
+++ b/src/utils/child-process.js
@@ -12,7 +12,7 @@ export function runProcess(cmd) {
     return new Promise((resolve, reject) => {
         const commands = cmd.split(SPACE);
         const [app, ...args] = commands;
-        const childProcess = spawn(app, args, { stdio: 'ignore' });
+        const childProcess = spawn(app, args);
 
         childProcess.on('error', (err) => {
             reject(err);


### PR DESCRIPTION
## Description

`child_process.spawn` has an option `stdio`.
When it is not set, it is treated as `pipe`. See: https://nodejs.org/api/child_process.html#child_process_options_stdio

When mode is `pipe` and spawned process has much data to output, it is blocked.
A brief PoC of this behavior is below: (Run `docker pull elgalu/selenium:latest` before this)
```node
const { spawn } = require('child_process');

const childProcess = spawn('docker', ['inspect', 'elgalu/selenium:latest']); // child precess blocked and never exit
// const childProcess = spawn('docker', ['inspect', 'elgalu/selenium:latest'], { stdio: 'ignore' }); // works fine

childProcess.on('exit', err => {
  console.log(`exit with ${err}`);
});
```

Actually, we can choose:
* set `{ stdio: 'ignore' }` to ignore spawned process's output
* set `childProcess.stdout.on('data')` to handle output

I chose the former.

## Checklist
- [ ] Unit/Integration test added (if applicable)
- [ ] Documentation added/updated (wiki or md)
- [x] Code style is consistent with the rest of the project
