### PR TITLE
bugfix: restore missing colorLogger (#38)

### DIFF
--- a/.npmignore
+++ b/.npmignore
@@ -7,4 +7,4 @@ PULL_REQUEST_TEMPLATE.md
 .babelrc
 .editorconfig
 .travis.yml
-*log*
+docker-log.txt

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "wdio-docker-service",
-  "version": "1.4.1",
+  "version": "1.4.2",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "wdio-docker-service",
-  "version": "1.4.1",
+  "version": "1.4.2",
   "description": "WebdriverIO service to start and stop docker container (for Selenium and more)",
   "repository": {
     "type": "git",


### PR DESCRIPTION
## Description
Fix issue #38 where `colorLogger.js` got excluded due to bad pattern in `.npmignore`

## Checklist
- [ ] Unit/Integration test added (if applicable)
- [ ] Documentation added/updated (wiki or md)
- [ ] Code style is consistent with the rest of the project
