### PR TITLE
Enable Docker container health check via shell command

### DIFF
--- a/README.md
+++ b/README.md
@@ -81,14 +81,13 @@ Type: `String|Object`
 
 Options for Object use:
 - *url* - url to an app running inside your container
-- *cmd* - command to check health of an app running inside your container
 - *maxRetries* - number of retries until healthcheck fails. Default: 10
 - *inspectInterval* - interval between each retry in ms. Default: 500
 - *startDelay* - initial delay to begin healthcheck in ms. Default: 0
 
 Example 1 (String): `healthCheck: 'http://localhost:4444'`
 
-Example 2 (Object with `url` check):
+Example 2 (Object):
 
 ```javascript
 healthCheck: {
@@ -98,21 +97,6 @@ healthCheck: {
     startDelay: 2000
 }
 ```
-
-Example 3 (Object with `cmd` check):
-
-When the Docker image implements a [`HEALTHCHECK`](https://docs.docker.com/engine/reference/builder/#healthcheck) you can use following configuration to wait until health status is `healthy`
-
-```javascript
-healthCheck: {
-    cmd: '[ $(docker inspect --format=\'{{json .State.Health.Status}}\' my-image) == "\\"healthy\\"" ] || exit 1',
-    maxRetries: 10,
-    inspectInterval: 1000
-}
-```
-
-
-
 
 ### dockerOptions.options
 Map of options used by `docker run` command. For more details on `run` command click [here](https://docs.docker.com/edge/engine/reference/commandline/run/).

--- a/README.md
+++ b/README.md
@@ -98,6 +98,8 @@ healthCheck: {
 }
 ```
 
+**REMARK:** If your Docker image defines a [`HEALTHCHECK`](https://docs.docker.com/engine/reference/builder/#healthcheck) the module will automatically poll check the health status of the container until it's `healthy` (no need to set `url` option)
+
 ### dockerOptions.options
 Map of options used by `docker run` command. For more details on `run` command click [here](https://docs.docker.com/edge/engine/reference/commandline/run/).
 

--- a/README.md
+++ b/README.md
@@ -81,13 +81,14 @@ Type: `String|Object`
 
 Options for Object use:
 - *url* - url to an app running inside your container
+- *cmd* - command to check health of an app running inside your container
 - *maxRetries* - number of retries until healthcheck fails. Default: 10
 - *inspectInterval* - interval between each retry in ms. Default: 500
 - *startDelay* - initial delay to begin healthcheck in ms. Default: 0
 
 Example 1 (String): `healthCheck: 'http://localhost:4444'`
 
-Example 2 (Object):
+Example 2 (Object with `url` check):
 
 ```javascript
 healthCheck: {
@@ -97,6 +98,21 @@ healthCheck: {
     startDelay: 2000
 }
 ```
+
+Example 3 (Object with `cmd` check):
+
+When the Docker image implements a [`HEALTHCHECK`](https://docs.docker.com/engine/reference/builder/#healthcheck) you can use following configuration to wait until health status is `healthy`
+
+```javascript
+healthCheck: {
+    cmd: '[ $(docker inspect --format=\'{{json .State.Health.Status}}\' my-image) == "\\"healthy\\"" ] || exit 1',
+    maxRetries: 10,
+    inspectInterval: 1000
+}
+```
+
+
+
 
 ### dockerOptions.options
 Map of options used by `docker run` command. For more details on `run` command click [here](https://docs.docker.com/edge/engine/reference/commandline/run/).

--- a/src/utils/childProcess.js
+++ b/src/utils/childProcess.js
@@ -33,7 +33,12 @@ export function runCommand(cmd) {
     return new Promise((resolve, reject) => {
         const commands = cmd.split(SPACE);
         const [app, ...args] = commands;
-        const childProcess = spawn(app, args, { stdio: 'ignore' });
+        const childProcess = spawn(app, args);
+        let stdout = '';
+
+        childProcess.stdout.on('data', (data) => {
+            stdout += data;
+        });
 
         childProcess.on('error', (err) => {
             reject(err);
@@ -41,7 +46,7 @@ export function runCommand(cmd) {
 
         childProcess.on('close', (code) => {
             if (!code) {
-                resolve(childProcess);
+                resolve(stdout);
                 return;
             }
 

--- a/src/utils/childProcess.js
+++ b/src/utils/childProcess.js
@@ -1,5 +1,7 @@
-import { exec } from 'child_process';
+import { spawn } from 'child_process';
 import Promise from 'bluebird';
+
+const SPACE = ' ';
 
 /**
  * Runs continuous shell process
@@ -8,7 +10,9 @@ import Promise from 'bluebird';
  */
 export function runProcess(cmd) {
     return new Promise((resolve, reject) => {
-        const childProcess = exec(cmd);
+        const commands = cmd.split(SPACE);
+        const [app, ...args] = commands;
+        const childProcess = spawn(app, args);
 
         childProcess.on('error', (err) => {
             reject(err);
@@ -27,7 +31,9 @@ export function runProcess(cmd) {
  */
 export function runCommand(cmd) {
     return new Promise((resolve, reject) => {
-        let childProcess = exec(cmd, { shell: true });
+        const commands = cmd.split(SPACE);
+        const [app, ...args] = commands;
+        const childProcess = spawn(app, args, { stdio: 'ignore' });
 
         childProcess.on('error', (err) => {
             reject(err);

--- a/src/utils/childProcess.js
+++ b/src/utils/childProcess.js
@@ -1,7 +1,5 @@
-import { spawn } from 'child_process';
+import { exec } from 'child_process';
 import Promise from 'bluebird';
-
-const SPACE = ' ';
 
 /**
  * Runs continuous shell process
@@ -10,9 +8,7 @@ const SPACE = ' ';
  */
 export function runProcess(cmd) {
     return new Promise((resolve, reject) => {
-        const commands = cmd.split(SPACE);
-        const [app, ...args] = commands;
-        const childProcess = spawn(app, args);
+        const childProcess = exec(cmd);
 
         childProcess.on('error', (err) => {
             reject(err);
@@ -31,9 +27,7 @@ export function runProcess(cmd) {
  */
 export function runCommand(cmd) {
     return new Promise((resolve, reject) => {
-        const commands = cmd.split(SPACE);
-        const [app, ...args] = commands;
-        const childProcess = spawn(app, args, { stdio: 'ignore' });
+        let childProcess = exec(cmd, { shell: true });
 
         childProcess.on('error', (err) => {
             reject(err);

--- a/src/utils/docker.js
+++ b/src/utils/docker.js
@@ -134,17 +134,14 @@ class Docker extends EventEmitter {
     _reportWhenDockerIsRunning() {
         const {
             url,
-            cmd,
             maxRetries = MAX_INSPECT_ATTEMPTS,
             inspectInterval = INSPECT_DOCKER_INTERVAL,
             startDelay = 0
         } = this.healthCheck;
 
-        if (url == undefined && cmd == undefined) {
+        if (url == undefined) {
             return Promise.resolve();
         }
-
-        let healthCheckFn = url ? () => { return Ping(url); }: () => { return runCommand(cmd); };
 
         return Promise.delay(startDelay)
             .then(() => new Promise((resolve, reject) => {
@@ -152,7 +149,7 @@ class Docker extends EventEmitter {
                 let pollstatus = null;
 
                 const poll = () => {
-                    healthCheckFn()
+                    Ping(url)
                         .then(() => {
                             resolve();
                             clearTimeout(pollstatus);

--- a/src/utils/docker.js
+++ b/src/utils/docker.js
@@ -134,14 +134,17 @@ class Docker extends EventEmitter {
     _reportWhenDockerIsRunning() {
         const {
             url,
+            cmd,
             maxRetries = MAX_INSPECT_ATTEMPTS,
             inspectInterval = INSPECT_DOCKER_INTERVAL,
             startDelay = 0
         } = this.healthCheck;
 
-        if (url == undefined) {
+        if (url == undefined && cmd == undefined) {
             return Promise.resolve();
         }
+
+        let healthCheckFn = url ? () => { return Ping(url); }: () => { return runCommand(cmd); };
 
         return Promise.delay(startDelay)
             .then(() => new Promise((resolve, reject) => {
@@ -149,7 +152,7 @@ class Docker extends EventEmitter {
                 let pollstatus = null;
 
                 const poll = () => {
-                    Ping(url)
+                    healthCheckFn()
                         .then(() => {
                             resolve();
                             clearTimeout(pollstatus);

--- a/test/mocks/MockChildProcess.js
+++ b/test/mocks/MockChildProcess.js
@@ -2,11 +2,10 @@ import { EventEmitter } from 'events';
 import { Readable } from 'stream';
 
 class MockChildProcess extends EventEmitter {
-    constructor(cmd, args = []) {
+    constructor(cmd) {
         super();
 
         this.cmd = cmd;
-        this.args = args;
 
         this.stdout = new Readable({
             read() {

--- a/test/mocks/MockChildProcess.js
+++ b/test/mocks/MockChildProcess.js
@@ -2,10 +2,11 @@ import { EventEmitter } from 'events';
 import { Readable } from 'stream';
 
 class MockChildProcess extends EventEmitter {
-    constructor(cmd) {
+    constructor(cmd, args = []) {
         super();
 
         this.cmd = cmd;
+        this.args = args;
 
         this.stdout = new Readable({
             read() {

--- a/test/unit/utils/childProcessSpec.js
+++ b/test/unit/utils/childProcessSpec.js
@@ -9,7 +9,7 @@ describe('Child Process utils', function () {
     describe('#runProcess', function () {
         context('when command fails to execute', function () {
             before(function () {
-                stub(ChildProcess, 'spawn').callsFake((cmd, args) => {
+                stub(ChildProcess, 'exec').callsFake((cmd, args) => {
                     const mp = new MockChildProcess(cmd, args);
 
                     process.nextTick(() => {
@@ -21,11 +21,11 @@ describe('Child Process utils', function () {
             });
 
             after(function () {
-                ChildProcess.spawn.restore();
+                ChildProcess.exec.restore();
             });
 
             it('must reject with error', function () {
-                return runProcess('foo', ['bar'])
+                return runProcess('foo bar')
                     .catch((err) => {
                         expect(err).to.be.instanceOf(Error);
                     });
@@ -34,14 +34,14 @@ describe('Child Process utils', function () {
 
         context('when command is successful', function () {
             before(function () {
-                stub(ChildProcess, 'spawn').callsFake((cmd, args) => {
+                stub(ChildProcess, 'exec').callsFake((cmd, args) => {
                     const mp = new MockChildProcess(cmd, args);
                     return mp;
                 });
             });
 
             after(function () {
-                ChildProcess.spawn.restore();
+                ChildProcess.exec.restore();
             });
 
             it('must resolve promise with child process', function () {
@@ -56,8 +56,8 @@ describe('Child Process utils', function () {
     describe('#runCommand', function () {
         context('when command fails to execute', function () {
             before(function () {
-                stub(ChildProcess, 'spawn').callsFake((cmd, args) => {
-                    const mp = new MockChildProcess(cmd, args);
+                stub(ChildProcess, 'exec').callsFake((cmd) => {
+                    const mp = new MockChildProcess(cmd);
 
                     process.nextTick(() => {
                         mp.mockError();
@@ -68,11 +68,11 @@ describe('Child Process utils', function () {
             });
 
             after(function () {
-                ChildProcess.spawn.restore();
+                ChildProcess.exec.restore();
             });
 
             it('must reject with error', function () {
-                return runCommand('foo', ['bar'])
+                return runCommand('foo bar')
                     .catch((err) => {
                         expect(err).to.be.instanceOf(Error);
                     });
@@ -81,8 +81,8 @@ describe('Child Process utils', function () {
 
         context('when command returns non 0 return code', function () {
             before(function () {
-                stub(ChildProcess, 'spawn').callsFake((cmd, args) => {
-                    const mp = new MockChildProcess(cmd, args);
+                stub(ChildProcess, 'exec').callsFake((cmd) => {
+                    const mp = new MockChildProcess(cmd);
 
                     process.nextTick(() => {
                         mp.mockClose(123);
@@ -93,22 +93,22 @@ describe('Child Process utils', function () {
             });
 
             after(function () {
-                ChildProcess.spawn.restore();
+                ChildProcess.exec.restore();
             });
 
             it('must reject with error', function () {
-                return runCommand('foo', ['bar'])
+                return runCommand('foo bar')
                     .catch((err) => {
                         expect(err).to.be.instanceOf(Error);
-                        expect(err.message).to.eql('Command \'foo\' exited with code 123');
+                        expect(err.message).to.eql('Command \'foo bar\' exited with code 123');
                     });
             });
         });
 
         context('when command runs successfully', function () {
             before(function () {
-                stub(ChildProcess, 'spawn').callsFake((cmd, args) => {
-                    const mp = new MockChildProcess(cmd, args);
+                stub(ChildProcess, 'exec').callsFake((cmd) => {
+                    const mp = new MockChildProcess(cmd);
 
                     process.nextTick(() => {
                         mp.mockClose(0);
@@ -119,11 +119,11 @@ describe('Child Process utils', function () {
             });
 
             after(function () {
-                ChildProcess.spawn.restore();
+                ChildProcess.exec.restore();
             });
 
             it('must resolve promise with child process', function () {
-                return runCommand('foo', ['bar'])
+                return runCommand('foo bar')
                     .then((childProcess) => {
                         expect(childProcess).to.be.instanceOf(MockChildProcess);
                     });

--- a/test/unit/utils/childProcessSpec.js
+++ b/test/unit/utils/childProcessSpec.js
@@ -9,7 +9,7 @@ describe('Child Process utils', function () {
     describe('#runProcess', function () {
         context('when command fails to execute', function () {
             before(function () {
-                stub(ChildProcess, 'exec').callsFake((cmd, args) => {
+                stub(ChildProcess, 'spawn').callsFake((cmd, args) => {
                     const mp = new MockChildProcess(cmd, args);
 
                     process.nextTick(() => {
@@ -21,11 +21,11 @@ describe('Child Process utils', function () {
             });
 
             after(function () {
-                ChildProcess.exec.restore();
+                ChildProcess.spawn.restore();
             });
 
             it('must reject with error', function () {
-                return runProcess('foo bar')
+                return runProcess('foo', ['bar'])
                     .catch((err) => {
                         expect(err).to.be.instanceOf(Error);
                     });
@@ -34,14 +34,14 @@ describe('Child Process utils', function () {
 
         context('when command is successful', function () {
             before(function () {
-                stub(ChildProcess, 'exec').callsFake((cmd, args) => {
+                stub(ChildProcess, 'spawn').callsFake((cmd, args) => {
                     const mp = new MockChildProcess(cmd, args);
                     return mp;
                 });
             });
 
             after(function () {
-                ChildProcess.exec.restore();
+                ChildProcess.spawn.restore();
             });
 
             it('must resolve promise with child process', function () {
@@ -56,8 +56,8 @@ describe('Child Process utils', function () {
     describe('#runCommand', function () {
         context('when command fails to execute', function () {
             before(function () {
-                stub(ChildProcess, 'exec').callsFake((cmd) => {
-                    const mp = new MockChildProcess(cmd);
+                stub(ChildProcess, 'spawn').callsFake((cmd, args) => {
+                    const mp = new MockChildProcess(cmd, args);
 
                     process.nextTick(() => {
                         mp.mockError();
@@ -68,11 +68,11 @@ describe('Child Process utils', function () {
             });
 
             after(function () {
-                ChildProcess.exec.restore();
+                ChildProcess.spawn.restore();
             });
 
             it('must reject with error', function () {
-                return runCommand('foo bar')
+                return runCommand('foo', ['bar'])
                     .catch((err) => {
                         expect(err).to.be.instanceOf(Error);
                     });
@@ -81,8 +81,8 @@ describe('Child Process utils', function () {
 
         context('when command returns non 0 return code', function () {
             before(function () {
-                stub(ChildProcess, 'exec').callsFake((cmd) => {
-                    const mp = new MockChildProcess(cmd);
+                stub(ChildProcess, 'spawn').callsFake((cmd, args) => {
+                    const mp = new MockChildProcess(cmd, args);
 
                     process.nextTick(() => {
                         mp.mockClose(123);
@@ -93,22 +93,22 @@ describe('Child Process utils', function () {
             });
 
             after(function () {
-                ChildProcess.exec.restore();
+                ChildProcess.spawn.restore();
             });
 
             it('must reject with error', function () {
-                return runCommand('foo bar')
+                return runCommand('foo', ['bar'])
                     .catch((err) => {
                         expect(err).to.be.instanceOf(Error);
-                        expect(err.message).to.eql('Command \'foo bar\' exited with code 123');
+                        expect(err.message).to.eql('Command \'foo\' exited with code 123');
                     });
             });
         });
 
         context('when command runs successfully', function () {
             before(function () {
-                stub(ChildProcess, 'exec').callsFake((cmd) => {
-                    const mp = new MockChildProcess(cmd);
+                stub(ChildProcess, 'spawn').callsFake((cmd, args) => {
+                    const mp = new MockChildProcess(cmd, args);
 
                     process.nextTick(() => {
                         mp.mockClose(0);
@@ -119,11 +119,11 @@ describe('Child Process utils', function () {
             });
 
             after(function () {
-                ChildProcess.exec.restore();
+                ChildProcess.spawn.restore();
             });
 
             it('must resolve promise with child process', function () {
-                return runCommand('foo bar')
+                return runCommand('foo', ['bar'])
                     .then((childProcess) => {
                         expect(childProcess).to.be.instanceOf(MockChildProcess);
                     });

--- a/test/unit/utils/childProcessSpec.js
+++ b/test/unit/utils/childProcessSpec.js
@@ -124,8 +124,8 @@ describe('Child Process utils', function () {
 
             it('must resolve promise with child process', function () {
                 return runCommand('foo', ['bar'])
-                    .then((childProcess) => {
-                        expect(childProcess).to.be.instanceOf(MockChildProcess);
+                    .then((output) => {
+                        expect(output).to.be.a.string;
                     });
             });
         });

--- a/test/unit/utils/dockerSpec.js
+++ b/test/unit/utils/dockerSpec.js
@@ -385,137 +385,79 @@ describe('Docker', function () {
         });
 
         context('when healthCheck is provided', function () {
+            const pingDef = require('../../../src/utils/ping');
 
-            context('when check is done via a url', function () {
-
-                context('when url is provided', function () {
-                    const pingDef = require('../../../src/utils/ping');
-
-                    before(function () {
-                        stub(pingDef, 'default').returns(Promise.resolve());
-                        spy(global, 'clearTimeout');
-                    });
-
-                    after(function () {
-                        pingDef.default.restore();
-                        global.clearTimeout.restore();
-                    });
-
-                    it('must Ping the healthCheck url', function () {
-                        const docker = new Docker('my-image', { healthCheck: 'http://localhost:8080' });
-
-                        return docker._reportWhenDockerIsRunning().then(() => {
-                            expect(global.clearTimeout.called).to.eql(true);
-                            expect(pingDef.default.calledWith('http://localhost:8080')).to.eql(true);
-                        });
-                    });
-                });
-
-                context('when maxRetries is specified and url is unreachable', function () {
-                    const pingDef = require('../../../src/utils/ping');
-
-                    before(function () {
-                        stub(pingDef, 'default').returns(Promise.reject());
-                        spy(global, 'clearTimeout');
-                    });
-
-                    after(function () {
-                        pingDef.default.restore();
-                        global.clearTimeout.restore();
-                    });
-
-                    it('must Ping same number of times as maxRetries', function () {
-                        const docker = new Docker('my-image', {
-                            healthCheck: {
-                                url: 'http://localhost:8080',
-                                maxRetries: 3
-                            }
-                        });
-
-                        this.timeout(15000);
-                        
-                        return docker._reportWhenDockerIsRunning().catch(() => {
-                            expect(global.clearTimeout.called).to.eql(true);
-                            expect(pingDef.default.calledThrice).to.eql(true);
-                        });
-                    });
-                });
-
-                context('when healthCheck is provided but is unreachable', function () {
-                    const pingDef = require('../../../src/utils/ping');
-
-                    before(function () {
-                        stub(pingDef, 'default').returns(Promise.reject());
-                        spy(global, 'clearTimeout');
-                    });
-
-                    after(function () {
-                        pingDef.default.restore();
-                        global.clearTimeout.restore();
-                    });
-
-                    it('must attempt to ping healthCheck url and then exit', function () {
-                        const docker = new Docker('my-image', { healthCheck: 'http://localhost:8080' });
-
-                        this.timeout(15000);
-
-                        return docker._reportWhenDockerIsRunning().catch(() => {
-                            expect(global.clearTimeout.called).to.eql(true);
-                            expect(pingDef.default.calledWith('http://localhost:8080')).to.eql(true);
-                        });
-                    });
-                });
+            before(function () {
+                stub(pingDef, 'default').returns(Promise.resolve());
+                spy(global, 'clearTimeout');
             });
 
-            context('when check is done via a command', function () {
+            after(function () {
+                pingDef.default.restore();
+                global.clearTimeout.restore();
+            });
 
-                context('when cmd is provided', function () {
-                    before(function () {
-                        stub(ChildProcess, 'runCommand').returns(Promise.resolve());
-                        spy(global, 'clearTimeout');
-                    });
-            
-                    after(function () {
-                        ChildProcess.runCommand.restore();
-                        global.clearTimeout.restore();
-                    });
+            it('must Ping the healthCheck url', function () {
+                const docker = new Docker('my-image', { healthCheck: 'http://localhost:8080' });
 
-                    it('must execute the healthCheck cmd', function () {
-                        const docker = new Docker('my-image', { healthCheck: { 'cmd': 'docker inspect my-image' }});
+                return docker._reportWhenDockerIsRunning().then(() => {
+                    expect(global.clearTimeout.called).to.eql(true);
+                    expect(pingDef.default.calledWith('http://localhost:8080')).to.eql(true);
+                });
+            });
+        });
 
-                        return docker._reportWhenDockerIsRunning().then(() => {
-                            expect(global.clearTimeout.called).to.eql(true);
-                            expect(ChildProcess.runCommand.calledWith('docker inspect my-image')).to.eql(true);
-                        });
-                    });
+        context('when maxRetries is specified and url is unreachable', function () {
+            const pingDef = require('../../../src/utils/ping');
+
+            before(function () {
+                stub(pingDef, 'default').returns(Promise.reject());
+                spy(global, 'clearTimeout');
+            });
+
+            after(function () {
+                pingDef.default.restore();
+                global.clearTimeout.restore();
+            });
+
+            it('must Ping same number of times as maxRetries', function () {
+                const docker = new Docker('my-image', {
+                    healthCheck: {
+                        url: 'http://localhost:8080',
+                        maxRetries: 3
+                    }
                 });
 
-                context('when maxRetries is specified and url is unreachable', function () {
-                    before(function () {
-                        stub(ChildProcess, 'runCommand').returns(Promise.reject());
-                        spy(global, 'clearTimeout');
-                    });
-            
-                    after(function () {
-                        ChildProcess.runCommand.restore();
-                        global.clearTimeout.restore();
-                    });
+                this.timeout(15000);
+                
+                return docker._reportWhenDockerIsRunning().catch(() => {
+                    expect(global.clearTimeout.called).to.eql(true);
+                    expect(pingDef.default.calledThrice).to.eql(true);
+                });
+            });
+        });
 
-                    it('must execute healthCheck cmd same number of times as maxRetries', function () {
-                        const docker = new Docker('my-image', {
-                            healthCheck: {
-                                cmd: 'docker inspect my-images',
-                                maxRetries: 3
-                            }
-                        });
+        context('when healthCheck is provided but is unreachable', function () {
+            const pingDef = require('../../../src/utils/ping');
 
-                        this.timeout(15000);
-                        
-                        return docker._reportWhenDockerIsRunning().catch(() => {
-                            expect(global.clearTimeout.called).to.eql(true);
-                            expect(ChildProcess.runCommand.calledThrice).to.eql(true);
-                        });
-                    });
+            before(function () {
+                stub(pingDef, 'default').returns(Promise.reject());
+                spy(global, 'clearTimeout');
+            });
+
+            after(function () {
+                pingDef.default.restore();
+                global.clearTimeout.restore();
+            });
+
+            it('must attempt to ping healthCheck url and then exit', function () {
+                const docker = new Docker('my-image', { healthCheck: 'http://localhost:8080' });
+
+                this.timeout(15000);
+
+                return docker._reportWhenDockerIsRunning().catch(() => {
+                    expect(global.clearTimeout.called).to.eql(true);
+                    expect(pingDef.default.calledWith('http://localhost:8080')).to.eql(true);
                 });
             });
         });

--- a/test/unit/utils/dockerSpec.js
+++ b/test/unit/utils/dockerSpec.js
@@ -138,12 +138,14 @@ describe('Docker', function () {
 
         beforeEach(function () {
             stub(ChildProcess, 'runProcess').returns(Promise.resolve(mockProcess));
+            stub(Docker.prototype, '_hasImageHealthcheck').returns(Promise.resolve());
             stub(Docker.prototype, '_removeStaleContainer').returns(Promise.resolve());
             stub(Docker.prototype, '_reportWhenDockerIsRunning').returns(Promise.resolve());
         });
 
         afterEach(function () {
             ChildProcess.runProcess.restore();
+            Docker.prototype._hasImageHealthcheck.restore();
             Docker.prototype._removeStaleContainer.restore();
             Docker.prototype._reportWhenDockerIsRunning.restore();
         });

--- a/test/unit/utils/dockerSpec.js
+++ b/test/unit/utils/dockerSpec.js
@@ -385,79 +385,137 @@ describe('Docker', function () {
         });
 
         context('when healthCheck is provided', function () {
-            const pingDef = require('../../../src/utils/ping');
 
-            before(function () {
-                stub(pingDef, 'default').returns(Promise.resolve());
-                spy(global, 'clearTimeout');
-            });
+            context('when check is done via a url', function () {
 
-            after(function () {
-                pingDef.default.restore();
-                global.clearTimeout.restore();
-            });
+                context('when url is provided', function () {
+                    const pingDef = require('../../../src/utils/ping');
 
-            it('must Ping the healthCheck url', function () {
-                const docker = new Docker('my-image', { healthCheck: 'http://localhost:8080' });
+                    before(function () {
+                        stub(pingDef, 'default').returns(Promise.resolve());
+                        spy(global, 'clearTimeout');
+                    });
 
-                return docker._reportWhenDockerIsRunning().then(() => {
-                    expect(global.clearTimeout.called).to.eql(true);
-                    expect(pingDef.default.calledWith('http://localhost:8080')).to.eql(true);
-                });
-            });
-        });
+                    after(function () {
+                        pingDef.default.restore();
+                        global.clearTimeout.restore();
+                    });
 
-        context('when maxRetries is specified and url is unreachable', function () {
-            const pingDef = require('../../../src/utils/ping');
+                    it('must Ping the healthCheck url', function () {
+                        const docker = new Docker('my-image', { healthCheck: 'http://localhost:8080' });
 
-            before(function () {
-                stub(pingDef, 'default').returns(Promise.reject());
-                spy(global, 'clearTimeout');
-            });
-
-            after(function () {
-                pingDef.default.restore();
-                global.clearTimeout.restore();
-            });
-
-            it('must Ping same number of times as maxRetries', function () {
-                const docker = new Docker('my-image', {
-                    healthCheck: {
-                        url: 'http://localhost:8080',
-                        maxRetries: 3
-                    }
+                        return docker._reportWhenDockerIsRunning().then(() => {
+                            expect(global.clearTimeout.called).to.eql(true);
+                            expect(pingDef.default.calledWith('http://localhost:8080')).to.eql(true);
+                        });
+                    });
                 });
 
-                this.timeout(15000);
-                
-                return docker._reportWhenDockerIsRunning().catch(() => {
-                    expect(global.clearTimeout.called).to.eql(true);
-                    expect(pingDef.default.calledThrice).to.eql(true);
+                context('when maxRetries is specified and url is unreachable', function () {
+                    const pingDef = require('../../../src/utils/ping');
+
+                    before(function () {
+                        stub(pingDef, 'default').returns(Promise.reject());
+                        spy(global, 'clearTimeout');
+                    });
+
+                    after(function () {
+                        pingDef.default.restore();
+                        global.clearTimeout.restore();
+                    });
+
+                    it('must Ping same number of times as maxRetries', function () {
+                        const docker = new Docker('my-image', {
+                            healthCheck: {
+                                url: 'http://localhost:8080',
+                                maxRetries: 3
+                            }
+                        });
+
+                        this.timeout(15000);
+                        
+                        return docker._reportWhenDockerIsRunning().catch(() => {
+                            expect(global.clearTimeout.called).to.eql(true);
+                            expect(pingDef.default.calledThrice).to.eql(true);
+                        });
+                    });
+                });
+
+                context('when healthCheck is provided but is unreachable', function () {
+                    const pingDef = require('../../../src/utils/ping');
+
+                    before(function () {
+                        stub(pingDef, 'default').returns(Promise.reject());
+                        spy(global, 'clearTimeout');
+                    });
+
+                    after(function () {
+                        pingDef.default.restore();
+                        global.clearTimeout.restore();
+                    });
+
+                    it('must attempt to ping healthCheck url and then exit', function () {
+                        const docker = new Docker('my-image', { healthCheck: 'http://localhost:8080' });
+
+                        this.timeout(15000);
+
+                        return docker._reportWhenDockerIsRunning().catch(() => {
+                            expect(global.clearTimeout.called).to.eql(true);
+                            expect(pingDef.default.calledWith('http://localhost:8080')).to.eql(true);
+                        });
+                    });
                 });
             });
-        });
 
-        context('when healthCheck is provided but is unreachable', function () {
-            const pingDef = require('../../../src/utils/ping');
+            context('when check is done via a command', function () {
 
-            before(function () {
-                stub(pingDef, 'default').returns(Promise.reject());
-                spy(global, 'clearTimeout');
-            });
+                context('when cmd is provided', function () {
+                    before(function () {
+                        stub(ChildProcess, 'runCommand').returns(Promise.resolve());
+                        spy(global, 'clearTimeout');
+                    });
+            
+                    after(function () {
+                        ChildProcess.runCommand.restore();
+                        global.clearTimeout.restore();
+                    });
 
-            after(function () {
-                pingDef.default.restore();
-                global.clearTimeout.restore();
-            });
+                    it('must execute the healthCheck cmd', function () {
+                        const docker = new Docker('my-image', { healthCheck: { 'cmd': 'docker inspect my-image' }});
 
-            it('must attempt to ping healthCheck url and then exit', function () {
-                const docker = new Docker('my-image', { healthCheck: 'http://localhost:8080' });
+                        return docker._reportWhenDockerIsRunning().then(() => {
+                            expect(global.clearTimeout.called).to.eql(true);
+                            expect(ChildProcess.runCommand.calledWith('docker inspect my-image')).to.eql(true);
+                        });
+                    });
+                });
 
-                this.timeout(15000);
+                context('when maxRetries is specified and url is unreachable', function () {
+                    before(function () {
+                        stub(ChildProcess, 'runCommand').returns(Promise.reject());
+                        spy(global, 'clearTimeout');
+                    });
+            
+                    after(function () {
+                        ChildProcess.runCommand.restore();
+                        global.clearTimeout.restore();
+                    });
 
-                return docker._reportWhenDockerIsRunning().catch(() => {
-                    expect(global.clearTimeout.called).to.eql(true);
-                    expect(pingDef.default.calledWith('http://localhost:8080')).to.eql(true);
+                    it('must execute healthCheck cmd same number of times as maxRetries', function () {
+                        const docker = new Docker('my-image', {
+                            healthCheck: {
+                                cmd: 'docker inspect my-images',
+                                maxRetries: 3
+                            }
+                        });
+
+                        this.timeout(15000);
+                        
+                        return docker._reportWhenDockerIsRunning().catch(() => {
+                            expect(global.clearTimeout.called).to.eql(true);
+                            expect(ChildProcess.runCommand.calledThrice).to.eql(true);
+                        });
+                    });
                 });
             });
         });


### PR DESCRIPTION
## Description
In our WDIO projects we use Selenium Docker images for which simple URL checking is not enough to determine readiness of the service (ex. [vvoyer/selenium-standalone](https://github.com/vvo/selenium-standalone/tree/master/docker)).

I propose an extension of dockerOptions.healthCheck to poll check the execution of a command until it returns 0.

The main use case is to execute a shell command to test the `health` status of a Docker container (for images which implement Docker [`HEALTHCHECK`](https://docs.docker.com/engine/reference/builder/#healthcheck)

## Checklist
- [x] Unit test added
- [x] Updated README
- [x] Code style is consistent with the rest of the project
