### PR TITLE
Fix docker stopping using watch mode

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,5 @@
 .idea
+.vscode
 /node_modules/
 /npm-debug.log
 /.nyc_output/

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "wdio-docker-service",
-  "version": "2.1.1",
+  "version": "2.1.2",
   "description": "WebdriverIO service to start and stop docker container (for Selenium and more)",
   "repository": {
     "type": "git",

--- a/src/launcher.js
+++ b/src/launcher.js
@@ -16,6 +16,7 @@ class DockerLauncher {
     onPrepare(config) {
         this.logToStdout = config.logToStdout;
         this.dockerLogs = config.dockerLogs;
+        this.watchMode = !!config.watch;
 
         Logger.setLevel(config.logLevel || 'info');
 
@@ -63,7 +64,7 @@ class DockerLauncher {
     }
 
     onComplete() {
-        if (this.docker) {
+        if (!this.watchMode && this.docker) {
             return this.docker.stop();
         }
     }
@@ -80,6 +81,12 @@ class DockerLauncher {
             this.docker.process.stdout.pipe(logStream);
             this.docker.process.stderr.pipe(logStream);
         });
+    }
+
+    _stopProcess() {
+        if (this.docker) {
+            this.docker.stop();
+        }
     }
 }
 

--- a/src/launcher.js
+++ b/src/launcher.js
@@ -64,8 +64,15 @@ class DockerLauncher {
     }
 
     onComplete() {
+        // do not stop docker if in watch mode
         if (!this.watchMode && this.docker) {
             return this.docker.stop();
+        }
+    }
+
+    afterSession() {
+        if (this.docker) {
+            this.docker.stop();
         }
     }
 
@@ -81,12 +88,6 @@ class DockerLauncher {
             this.docker.process.stdout.pipe(logStream);
             this.docker.process.stderr.pipe(logStream);
         });
-    }
-
-    _stopProcess() {
-        if (this.docker) {
-            this.docker.stop();
-        }
     }
 }
 

--- a/test/unit/launcherSpec.js
+++ b/test/unit/launcherSpec.js
@@ -220,5 +220,30 @@ describe('DockerLauncher', function() {
                 expect(launcher.docker.stop.called).to.eql(true);
             });
         });
+
+        context('when this.watchMode is present', function() {
+            it('must not call this.docker.stop', function() {
+                launcher.watchMode = true;
+                launcher.docker = {
+                    stop: spy()
+                };
+
+                launcher.onComplete();
+                expect(launcher.docker.stop.called).to.eql(false);
+            });
+        });
+    });
+
+    describe('#afterSession', function() {
+        context('when this.docker is present', function() {
+            it('must call this.docker.stop', function() {
+                launcher.docker = {
+                    stop: spy()
+                };
+
+                launcher.afterSession();
+                expect(launcher.docker.stop.called).to.eql(true);
+            });
+        });
     });
 });


### PR DESCRIPTION
## Description
When running tests using watch model, the onComplete hook fires when the test run completes while waiting for new changes.  In version v4 of webdriverio the onComplete hook didn't get called, but with v5 it does causing the docker container to shut down.  This prevents users from using watch mode with the docker service.
The onComplete is called when performing a single test run that will stop docker.  The afterSession is called when watch mode is exited.

## Checklist
- [x] Unit/Integration test added (if applicable)
- [ ] Documentation added/updated (wiki or md)
- [x] Code style is consistent with the rest of the project
