### PR TITLE
fix(doc): updated readme.md file with correct WDIO installation page URL

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@ Run:
 npm install wdio-docker-service --save-dev
 ```
 
-Instructions on how to install WebdriverIO can be found [here](http://webdriver.io/guide/getstarted/install.html).
+Instructions on how to install WebdriverIO can be found [here](https://webdriver.io/docs/gettingstarted).
 
 ## Configuration
 By default, Google Chrome, Firefox and PhantomJS are available when installed on the host system. 


### PR DESCRIPTION
## Description
updated readme.md file with correct WDIO installation page URL. that is https://webdriver.io/docs/gettingstarted.

## Checklist
- [ ] Unit/Integration test added (if applicable)
- [x] Documentation added/updated (wiki or md)
- [ ] Code style is consistent with the rest of the project

<img width="702" alt="Screen Shot 2022-12-16 at 1 32 06 PM" src="https://user-images.githubusercontent.com/8421048/208165795-a63401e2-3635-488b-91af-967d07b00379.png">

